### PR TITLE
Using FlatBuffer Java API JAR provided by Google

### DIFF
--- a/src/main/groovy/io/netifi/flatbuffers/plugin/FlatBuffersPlugin.groovy
+++ b/src/main/groovy/io/netifi/flatbuffers/plugin/FlatBuffersPlugin.groovy
@@ -106,7 +106,7 @@ class FlatBuffersPlugin implements Plugin<Project> {
         // Java specific dependencies
         if (project.plugins.hasPlugin(JavaPlugin)) {
             project.dependencies {
-                compile 'com.github.davidmoten:flatbuffers-java:1.4.0.1'
+                compile 'com.google.flatbuffers:flatbuffers-java:1.8.0'
             }
         }
     }


### PR DESCRIPTION
I realized that Google in the meantime publishes Java FlatBuffer API JARs on Maven, see [here](https://mvnrepository.com/artifact/com.google.flatbuffers/flatbuffers-java).

Can we use this JAR instead of the 3rd party build? The latter was great but now that an official JAR is available, let's use it.