### PR TITLE
Fix Javascript Generation

### DIFF
--- a/src/main/groovy/io/netifi/flatbuffers/plugin/FlatBuffersLanguage.groovy
+++ b/src/main/groovy/io/netifi/flatbuffers/plugin/FlatBuffersLanguage.groovy
@@ -26,7 +26,7 @@ enum FlatBuffersLanguage {
     C_SHARP("csharp"),
     GO("go"),
     PYTHON("python"),
-    JAVASCRIPT("javascript"),
+    JAVASCRIPT("js"),
     PHP("php"),
     GRPC("grpc")
 


### PR DESCRIPTION
`js` is the correct command line flag to `flatc`