### PR TITLE
Add extra args support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This task type compiles FlatBuffers schemas.
         inputDir = file("src/main/flatbuffers")
         outputDir = file("src/generated/flatbuffers")
         language = 'java'
+        extraArgs = '--grpc'
     }
 ```
 
@@ -45,6 +46,7 @@ This task type compiles FlatBuffers schemas.
 | inputDir  | File   | `src/main/flatbuffers` | False    | The path to the schemas directory.                  |
 | outputDir | File   | null                   | True     | The path to the directory for compiled FlatBuffers. | 
 | language  | String | value in extension     | False    | The language to use when compiling the schemas.     |
+| extraArgs | String | null                   | False    | Any additional arguments to flatc (e.g., --grpc)    |
 
 
 *Note:* Please see the [Supported Languages](#supported-languages) section for valid `language` values.

--- a/src/main/groovy/io/netifi/flatbuffers/plugin/tasks/FlatBuffers.groovy
+++ b/src/main/groovy/io/netifi/flatbuffers/plugin/tasks/FlatBuffers.groovy
@@ -36,6 +36,7 @@ class FlatBuffers extends DefaultTask {
     private File inputDir
     private File outputDir
     private String language
+    private String extraArgs = new String()
 
     @TaskAction
     void run() {
@@ -46,7 +47,7 @@ class FlatBuffers extends DefaultTask {
         getSchemas().each {
             println "Compiling: '${it}'"
 
-            def cmd = "${flatcPath} --${language} -o ${outputDir} ${it}"
+            def cmd = "${flatcPath} --${language} -o ${outputDir} ${extraArgs} ${it}"
 
             getLogger().debug("Running command: '${cmd}'")
 
@@ -196,6 +197,16 @@ class FlatBuffers extends DefaultTask {
 
     void setLanguage(String language) {
         this.language = language
+    }
+
+    void setExtraArgs(String extraArgs) {
+        this.extraArgs = extraArgs 
+    }
+
+    @Optional
+    @Input
+    String getExtraArgs() {
+        return this.extraArgs;
     }
 
 }


### PR DESCRIPTION
Allow passing `extraArgs` in `FlatBuffers` task. For example, "--grpc"

```$groovy
    task createFlatBuffers(type: FlatBuffers) {
        inputDir = file("src/main/flatbuffers")
        outputDir = file("src/generated/flatbuffers")
        language = 'java'
        extraArgs = '--grpc'
    }   
```